### PR TITLE
Syncable script-driven bounce animation for interactable tiles

### DIFF
--- a/HeximperiumProject/Assets/Scripts/Managers/EntertainmentManager.cs
+++ b/HeximperiumProject/Assets/Scripts/Managers/EntertainmentManager.cs
@@ -266,7 +266,6 @@ public class EntertainmentManager : PhaseManager<EntertainmentManager>
         if (_syncAnimationFromPreviousPhase)
         {
             _animWasPlaying = ExploitationManager.Instance.AnimWasPlaying;
-            _stateInfo = ExploitationManager.Instance.StateInfo;
             _progress = ExploitationManager.Instance.Progress;
             _syncAnimationFromPreviousPhase = false;
         }
@@ -285,6 +284,6 @@ public class EntertainmentManager : PhaseManager<EntertainmentManager>
             }
         }
 
-        _interactableTilesCoroutine = StartCoroutine(PlayInteractableAnimation(_animWasPlaying, _progress, _stateInfo));
+        _interactableTilesCoroutine = StartCoroutine(PlayInteractableAnimation(_animWasPlaying, _progress));
     }
 }

--- a/HeximperiumProject/Assets/Scripts/Managers/ExpansionManager.cs
+++ b/HeximperiumProject/Assets/Scripts/Managers/ExpansionManager.cs
@@ -206,7 +206,6 @@ public class ExpansionManager : PhaseManager<ExpansionManager>
         if (_syncAnimationFromPreviousPhase)
         {
             _animWasPlaying = ExplorationManager.Instance.AnimWasPlaying;
-            _stateInfo = ExplorationManager.Instance.StateInfo;
             _progress = ExplorationManager.Instance.Progress;
             _syncAnimationFromPreviousPhase = false;
         }
@@ -243,6 +242,6 @@ public class ExpansionManager : PhaseManager<ExpansionManager>
             }
         }
 
-        _interactableTilesCoroutine = StartCoroutine(PlayInteractableAnimation(_animWasPlaying, _progress, _stateInfo));
+        _interactableTilesCoroutine = StartCoroutine(PlayInteractableAnimation(_animWasPlaying, _progress));
     }
 }

--- a/HeximperiumProject/Assets/Scripts/Managers/ExploitationManager.cs
+++ b/HeximperiumProject/Assets/Scripts/Managers/ExploitationManager.cs
@@ -287,7 +287,6 @@ public class ExploitationManager : PhaseManager<ExploitationManager>
         if (_syncAnimationFromPreviousPhase)
         {
             _animWasPlaying = ExpansionManager.Instance.AnimWasPlaying;
-            _stateInfo = ExpansionManager.Instance.StateInfo;
             _progress = ExpansionManager.Instance.Progress;
             _syncAnimationFromPreviousPhase = false;
         }
@@ -304,6 +303,6 @@ public class ExploitationManager : PhaseManager<ExploitationManager>
             }
         }
 
-        _interactableTilesCoroutine = StartCoroutine(PlayInteractableAnimation(_animWasPlaying, _progress, _stateInfo));
+        _interactableTilesCoroutine = StartCoroutine(PlayInteractableAnimation(_animWasPlaying, _progress));
     }
 }

--- a/HeximperiumProject/Assets/Scripts/Managers/ExplorationManager.cs
+++ b/HeximperiumProject/Assets/Scripts/Managers/ExplorationManager.cs
@@ -323,7 +323,6 @@ public class ExplorationManager : PhaseManager<ExplorationManager>
         if (_syncAnimationFromPreviousPhase)
         {
             _animWasPlaying = ExploitationManager.Instance.AnimWasPlaying;
-            _stateInfo = ExploitationManager.Instance.StateInfo;
             _progress = ExploitationManager.Instance.Progress;
             _syncAnimationFromPreviousPhase = false;
         }
@@ -356,6 +355,6 @@ public class ExplorationManager : PhaseManager<ExplorationManager>
             }
         }
 
-        _interactableTilesCoroutine = StartCoroutine(PlayInteractableAnimation(_animWasPlaying, _progress, _stateInfo));
+        _interactableTilesCoroutine = StartCoroutine(PlayInteractableAnimation(_animWasPlaying, _progress));
     }
 }

--- a/HeximperiumProject/Assets/Scripts/Managers/PhaseManager.cs
+++ b/HeximperiumProject/Assets/Scripts/Managers/PhaseManager.cs
@@ -2,7 +2,6 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using System;
-using System.Linq;
 
 public abstract class PhaseManager<T> : Singleton<T> where T : MonoBehaviour
 {
@@ -11,14 +10,16 @@ public abstract class PhaseManager<T> : Singleton<T> where T : MonoBehaviour
 
     //Variables for animated tiles
     protected HashSet<Tile> _animatedTiles = new HashSet<Tile>();
+    protected Dictionary<Tile, Vector3> _initialPositions = new Dictionary<Tile, Vector3>();
     protected Coroutine _interactableTilesCoroutine;
     protected bool _animWasPlaying = false;
-    protected AnimatorStateInfo _stateInfo = default;
     protected float _progress = 0f;
     protected bool _syncAnimationFromPreviousPhase = true;
+    protected float _bounceStartTime = 0f;
+    protected const float _bouncePeriod = 1f;
+    protected const float _bounceHeight = 0.1f;
 
     public bool AnimWasPlaying { get => _animWasPlaying; }
-    public AnimatorStateInfo StateInfo { get => _stateInfo; }
     public float Progress { get => _progress; }
 
     public event Action OnPhaseFinalized;
@@ -77,33 +78,51 @@ public abstract class PhaseManager<T> : Singleton<T> where T : MonoBehaviour
 
         foreach (Tile tile in _animatedTiles)
         {
-            tile.Animator.SetBool("Interactable", false);
+            if (_initialPositions.TryGetValue(tile, out Vector3 pos))
+            {
+                tile.Visual.localPosition = pos;
+            }
         }
         _animatedTiles.Clear();
+        _initialPositions.Clear();
     }
 
-    protected IEnumerator PlayInteractableAnimation(bool animWasPlaying, float progress, AnimatorStateInfo stateInfo)
+    protected IEnumerator PlayInteractableAnimation(bool animWasPlaying, float progress)
     {
-        yield return new WaitForEndOfFrame();
+        yield return null;
+        _bounceStartTime = Time.time - progress * _bouncePeriod;
         foreach (Tile tile in _animatedTiles)
         {
-            tile.Animator.SetBool("Interactable", true);
-            if (animWasPlaying)
-                tile.Animator.Play(stateInfo.shortNameHash, 0, progress);
+            if (!_initialPositions.ContainsKey(tile))
+                _initialPositions[tile] = tile.Visual.localPosition;
+        }
+
+        while (_animatedTiles.Count > 0)
+        {
+            float phase = (Time.time - _bounceStartTime) / _bouncePeriod;
+            float offset = Mathf.Sin(phase * Mathf.PI * 2f) * _bounceHeight;
+            foreach (Tile tile in _animatedTiles)
+            {
+                if (_initialPositions.TryGetValue(tile, out Vector3 basePos))
+                {
+                    tile.Visual.localPosition = new Vector3(basePos.x, basePos.y + offset, basePos.z);
+                }
+            }
+            yield return null;
         }
         _interactableTilesCoroutine = null;
     }
 
     protected void SyncAnimationInteractableTiles()
     {
-        _animWasPlaying = false;
-        _stateInfo = default;
-        _progress = 0f;
-        if (_animatedTiles.Count > 0)
+        _animWasPlaying = _animatedTiles.Count > 0;
+        if (_animWasPlaying)
         {
-            _stateInfo = _animatedTiles.FirstOrDefault().Animator.GetCurrentAnimatorStateInfo(0);
-            _progress = _stateInfo.normalizedTime % 1f;
-            _animWasPlaying = true;
+            _progress = ((Time.time - _bounceStartTime) / _bouncePeriod) % 1f;
+        }
+        else
+        {
+            _progress = 0f;
         }
     }
 }


### PR DESCRIPTION
## Summary
- replace animator-based tile highlighting with coroutine-driven vertical bounce
- synchronize bouncing tiles when list updates or phases change

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b602662f88832cb08ebaee8efe4502