### PR TITLE
Syncable script-driven bounce animation for interactable tiles

### DIFF
--- a/HeximperiumProject/Assets/Scripts/Managers/EntertainmentManager.cs
+++ b/HeximperiumProject/Assets/Scripts/Managers/EntertainmentManager.cs
@@ -266,25 +266,20 @@ public class EntertainmentManager : PhaseManager<EntertainmentManager>
         if (_syncAnimationFromPreviousPhase)
         {
             _animWasPlaying = ExploitationManager.Instance.AnimWasPlaying;
-            _stateInfo = ExploitationManager.Instance.StateInfo;
             _progress = ExploitationManager.Instance.Progress;
             _syncAnimationFromPreviousPhase = false;
         }
-        else
-            SyncAnimationInteractableTiles();
-
-        StopAnimationInteractableTiles();
+        HashSet<Tile> newTiles = new HashSet<Tile>();
 
         if (IsAtLeastOneEntertainmentBuyable())
         {
             foreach (Tile tile in ExpansionManager.Instance.ClaimedTiles)
             {
-                if (tile.Entertainment != null)
-                    continue;
-                _animatedTiles.Add(tile);
+                if (tile.Entertainment == null)
+                    newTiles.Add(tile);
             }
         }
 
-        _interactableTilesCoroutine = StartCoroutine(PlayInteractableAnimation(_animWasPlaying, _progress, _stateInfo));
+        ApplyAnimatedTiles(newTiles);
     }
 }

--- a/HeximperiumProject/Assets/Scripts/Managers/ExpansionManager.cs
+++ b/HeximperiumProject/Assets/Scripts/Managers/ExpansionManager.cs
@@ -206,14 +206,10 @@ public class ExpansionManager : PhaseManager<ExpansionManager>
         if (_syncAnimationFromPreviousPhase)
         {
             _animWasPlaying = ExplorationManager.Instance.AnimWasPlaying;
-            _stateInfo = ExplorationManager.Instance.StateInfo;
             _progress = ExplorationManager.Instance.Progress;
             _syncAnimationFromPreviousPhase = false;
         }
-        else
-            SyncAnimationInteractableTiles();
-
-        StopAnimationInteractableTiles();
+        HashSet<Tile> newTiles = new HashSet<Tile>();
 
         foreach (Tile tile in ExplorationManager.Instance.RevealedTiles)
         {
@@ -223,7 +219,7 @@ public class ExpansionManager : PhaseManager<ExpansionManager>
                     continue;
                 else if (ResourcesManager.Instance.CanAffordClaim(_townData.ClaimCost) && ExploitationManager.Instance.IsInfraAvailable(_townData))
                 {
-                    _animatedTiles.Add(tile);
+                    newTiles.Add(tile);
                 }
             }
             else
@@ -232,17 +228,17 @@ public class ExpansionManager : PhaseManager<ExpansionManager>
                 {
                     if (ResourcesManager.Instance.CanAffordClaim(tile.TileData.ClaimCost))
                     {
-                        _animatedTiles.Add(tile);
+                        newTiles.Add(tile);
                         continue;
                     }
                 }
                 if (tile.TileData is BasicTileData && ResourcesManager.Instance.CanAffordClaim(_townData.ClaimCost) && ExploitationManager.Instance.IsInfraAvailable(_townData))
                 {
-                    _animatedTiles.Add(tile);
+                    newTiles.Add(tile);
                 }
             }
         }
 
-        _interactableTilesCoroutine = StartCoroutine(PlayInteractableAnimation(_animWasPlaying, _progress, _stateInfo));
+        ApplyAnimatedTiles(newTiles);
     }
 }

--- a/HeximperiumProject/Assets/Scripts/Managers/ExploitationManager.cs
+++ b/HeximperiumProject/Assets/Scripts/Managers/ExploitationManager.cs
@@ -287,23 +287,19 @@ public class ExploitationManager : PhaseManager<ExploitationManager>
         if (_syncAnimationFromPreviousPhase)
         {
             _animWasPlaying = ExpansionManager.Instance.AnimWasPlaying;
-            _stateInfo = ExpansionManager.Instance.StateInfo;
             _progress = ExpansionManager.Instance.Progress;
             _syncAnimationFromPreviousPhase = false;
         }
-        else
-            SyncAnimationInteractableTiles();
-
-        StopAnimationInteractableTiles();
+        HashSet<Tile> newTiles = new HashSet<Tile>();
 
         foreach (Tile tile in ExpansionManager.Instance.ClaimedTiles)
         {
             if (tile.TileEnhanceable())
             {
-                _animatedTiles.Add(tile);
+                newTiles.Add(tile);
             }
         }
 
-        _interactableTilesCoroutine = StartCoroutine(PlayInteractableAnimation(_animWasPlaying, _progress, _stateInfo));
+        ApplyAnimatedTiles(newTiles);
     }
 }

--- a/HeximperiumProject/Assets/Scripts/Managers/ExplorationManager.cs
+++ b/HeximperiumProject/Assets/Scripts/Managers/ExplorationManager.cs
@@ -323,14 +323,10 @@ public class ExplorationManager : PhaseManager<ExplorationManager>
         if (_syncAnimationFromPreviousPhase)
         {
             _animWasPlaying = ExploitationManager.Instance.AnimWasPlaying;
-            _stateInfo = ExploitationManager.Instance.StateInfo;
             _progress = ExploitationManager.Instance.Progress;
             _syncAnimationFromPreviousPhase = false;
         }
-        else
-            SyncAnimationInteractableTiles();
-
-        StopAnimationInteractableTiles();
+        HashSet<Tile> newTiles = new HashSet<Tile>();
 
         if (_currentScoutsCount < _scoutsLimit)
         {
@@ -340,7 +336,7 @@ public class ExplorationManager : PhaseManager<ExplorationManager>
                 {
                     if (data.ScoutStartingPoint)
                     {
-                        _animatedTiles.Add(tile);
+                        newTiles.Add(tile);
                     }
                 }
             }
@@ -351,11 +347,11 @@ public class ExplorationManager : PhaseManager<ExplorationManager>
             {
                 if (!scout.HasRedirected)
                 {
-                    _animatedTiles.Add(scout.CurrentTile);
+                    newTiles.Add(scout.CurrentTile);
                 }
             }
         }
 
-        _interactableTilesCoroutine = StartCoroutine(PlayInteractableAnimation(_animWasPlaying, _progress, _stateInfo));
+        ApplyAnimatedTiles(newTiles);
     }
 }

--- a/HeximperiumProject/Assets/Scripts/Managers/PhaseManager.cs
+++ b/HeximperiumProject/Assets/Scripts/Managers/PhaseManager.cs
@@ -2,7 +2,6 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using System;
-using System.Linq;
 
 public abstract class PhaseManager<T> : Singleton<T> where T : MonoBehaviour
 {
@@ -11,14 +10,18 @@ public abstract class PhaseManager<T> : Singleton<T> where T : MonoBehaviour
 
     //Variables for animated tiles
     protected HashSet<Tile> _animatedTiles = new HashSet<Tile>();
+    protected Dictionary<Tile, Vector3> _initialPositions = new Dictionary<Tile, Vector3>();
     protected Coroutine _interactableTilesCoroutine;
+    private Dictionary<Tile, Coroutine> _returnCoroutines = new Dictionary<Tile, Coroutine>();
     protected bool _animWasPlaying = false;
-    protected AnimatorStateInfo _stateInfo = default;
     protected float _progress = 0f;
     protected bool _syncAnimationFromPreviousPhase = true;
+    protected float _bounceStartTime = 0f;
+    protected const float _bouncePeriod = 1f;
+    protected const float _bounceHeight = 0.1f;
+    protected const float _returnDuration = 0.15f;
 
     public bool AnimWasPlaying { get => _animWasPlaying; }
-    public AnimatorStateInfo StateInfo { get => _stateInfo; }
     public float Progress { get => _progress; }
 
     public event Action OnPhaseFinalized;
@@ -63,47 +66,173 @@ public abstract class PhaseManager<T> : Singleton<T> where T : MonoBehaviour
     public void EndPhaseStopAnimation()
     {
         SyncAnimationInteractableTiles();
-        StopAnimationInteractableTiles();
+        StopAnimationInteractableTiles(true);
         _syncAnimationFromPreviousPhase = true;
     }
 
-    protected void StopAnimationInteractableTiles()
+    protected void StopAnimationInteractableTiles(bool smoothReturn = false)
     {
         if (_interactableTilesCoroutine != null)
         {
             StopCoroutine(_interactableTilesCoroutine);
             _interactableTilesCoroutine = null;
         }
-
-        foreach (Tile tile in _animatedTiles)
+        if (!smoothReturn)
         {
-            tile.Animator.SetBool("Interactable", false);
+            foreach (var kvp in _returnCoroutines)
+            {
+                StopCoroutine(kvp.Value);
+            }
+            _returnCoroutines.Clear();
         }
-        _animatedTiles.Clear();
+        if (smoothReturn && _animatedTiles.Count > 0)
+        {
+            _interactableTilesCoroutine = StartCoroutine(ReturnTilesToInitialPositions());
+        }
+        else
+        {
+            foreach (var kvp in _initialPositions)
+            {
+                kvp.Key.Visual.localPosition = kvp.Value;
+            }
+            _animatedTiles.Clear();
+            _initialPositions.Clear();
+        }
     }
 
-    protected IEnumerator PlayInteractableAnimation(bool animWasPlaying, float progress, AnimatorStateInfo stateInfo)
+    protected void ApplyAnimatedTiles(HashSet<Tile> newTiles)
     {
-        yield return new WaitForEndOfFrame();
+        var toRemove = new HashSet<Tile>(_animatedTiles);
+        toRemove.ExceptWith(newTiles);
+        foreach (Tile tile in toRemove)
+        {
+            _animatedTiles.Remove(tile);
+            if (_returnCoroutines.TryGetValue(tile, out Coroutine existing))
+            {
+                StopCoroutine(existing);
+            }
+            if (_initialPositions.ContainsKey(tile))
+            {
+                _returnCoroutines[tile] = StartCoroutine(ReturnTileToInitialPosition(tile));
+            }
+        }
+
+        foreach (Tile tile in newTiles)
+        {
+            if (_animatedTiles.Contains(tile))
+                continue;
+            if (_returnCoroutines.TryGetValue(tile, out Coroutine returning))
+            {
+                StopCoroutine(returning);
+                _returnCoroutines.Remove(tile);
+            }
+            if (!_initialPositions.ContainsKey(tile))
+                _initialPositions[tile] = tile.Visual.localPosition;
+            _animatedTiles.Add(tile);
+        }
+
+        if (_animatedTiles.Count > 0)
+        {
+            if (_interactableTilesCoroutine == null)
+                _interactableTilesCoroutine = StartCoroutine(PlayInteractableAnimation(_animWasPlaying, _progress));
+        }
+        else if (_interactableTilesCoroutine != null)
+        {
+            StopCoroutine(_interactableTilesCoroutine);
+            _interactableTilesCoroutine = null;
+        }
+    }
+
+    protected IEnumerator PlayInteractableAnimation(bool animWasPlaying, float progress)
+    {
+        yield return null;
+        _bounceStartTime = Time.time - progress * _bouncePeriod;
         foreach (Tile tile in _animatedTiles)
         {
-            tile.Animator.SetBool("Interactable", true);
-            if (animWasPlaying)
-                tile.Animator.Play(stateInfo.shortNameHash, 0, progress);
+            if (!_initialPositions.ContainsKey(tile))
+                _initialPositions[tile] = tile.Visual.localPosition;
+        }
+
+        while (_animatedTiles.Count > 0)
+        {
+            float phase = (Time.time - _bounceStartTime) / _bouncePeriod;
+            float offset = Mathf.Sin(phase * Mathf.PI * 2f) * _bounceHeight;
+            foreach (Tile tile in _animatedTiles)
+            {
+                if (_initialPositions.TryGetValue(tile, out Vector3 basePos))
+                {
+                    tile.Visual.localPosition = new Vector3(basePos.x, basePos.y + offset, basePos.z);
+                }
+            }
+            yield return null;
         }
         _interactableTilesCoroutine = null;
     }
 
+    private IEnumerator ReturnTilesToInitialPositions()
+    {
+        Dictionary<Tile, Vector3> startPositions = new Dictionary<Tile, Vector3>();
+        foreach (Tile tile in _animatedTiles)
+        {
+            startPositions[tile] = tile.Visual.localPosition;
+        }
+
+        float elapsed = 0f;
+        while (elapsed < _returnDuration)
+        {
+            elapsed += Time.deltaTime;
+            float t = Mathf.Clamp01(elapsed / _returnDuration);
+            foreach (Tile tile in _animatedTiles)
+            {
+                if (startPositions.TryGetValue(tile, out Vector3 start) &&
+                    _initialPositions.TryGetValue(tile, out Vector3 target))
+                {
+                    tile.Visual.localPosition = Vector3.Lerp(start, target, t);
+                }
+            }
+            yield return null;
+        }
+
+        foreach (Tile tile in _animatedTiles)
+        {
+            if (_initialPositions.TryGetValue(tile, out Vector3 pos))
+            {
+                tile.Visual.localPosition = pos;
+            }
+        }
+        _animatedTiles.Clear();
+        _initialPositions.Clear();
+        _interactableTilesCoroutine = null;
+    }
+
+    private IEnumerator ReturnTileToInitialPosition(Tile tile)
+    {
+        Vector3 start = tile.Visual.localPosition;
+        if (!_initialPositions.TryGetValue(tile, out Vector3 target))
+            yield break;
+        float elapsed = 0f;
+        while (elapsed < _returnDuration)
+        {
+            elapsed += Time.deltaTime;
+            float t = Mathf.Clamp01(elapsed / _returnDuration);
+            tile.Visual.localPosition = Vector3.Lerp(start, target, t);
+            yield return null;
+        }
+        tile.Visual.localPosition = target;
+        _initialPositions.Remove(tile);
+        _returnCoroutines.Remove(tile);
+    }
+
     protected void SyncAnimationInteractableTiles()
     {
-        _animWasPlaying = false;
-        _stateInfo = default;
-        _progress = 0f;
-        if (_animatedTiles.Count > 0)
+        _animWasPlaying = _animatedTiles.Count > 0;
+        if (_animWasPlaying)
         {
-            _stateInfo = _animatedTiles.FirstOrDefault().Animator.GetCurrentAnimatorStateInfo(0);
-            _progress = _stateInfo.normalizedTime % 1f;
-            _animWasPlaying = true;
+            _progress = ((Time.time - _bounceStartTime) / _bouncePeriod) % 1f;
+        }
+        else
+        {
+            _progress = 0f;
         }
     }
 }


### PR DESCRIPTION
## Summary
- allow tiles leaving the bounce list to smoothly lerp back to base position
- add `ApplyAnimatedTiles` helper to diff current and new tile sets
- managers now rebuild a set of animated tiles and apply it instead of restarting animation

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b602662f88832cb08ebaee8efe4502